### PR TITLE
Fade rival out of player's room

### DIFF
--- a/assembly/overworld_scripts/pallet_town/player_room.s
+++ b/assembly/overworld_scripts/pallet_town/player_room.s
@@ -120,7 +120,9 @@ Rival_Exits:
   applymovement PERSON_RIVAL Move_Rival_Exits
   waitmovement 0x0
   sound SOUND_EXIT_ROOM
+  fadescreen FADEOUT_BLACK
   hidesprite PERSON_RIVAL
+  fadescreen FADEIN_BLACK
   return
 
 Move_Rival_Exits:
@@ -134,11 +136,6 @@ Move_Rival_Exits:
   .byte run_right
   .byte run_right
   .byte run_right
-  .byte run_right
-  .byte run_up
-  .byte run_up
-  .byte walk_left
-  .byte walk_left
   .byte end_m
 
 SetHealingPlaceToHome:


### PR DESCRIPTION
Fades to black when Rival leaves room, rather than disappearing at the stairs.